### PR TITLE
Exchanged contraction on text screwing with code highlighting.

### DIFF
--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -75,7 +75,7 @@
       <% if(me&&me.emailChangeCandidate) { %>
       <div class="container-fluid">
         <div class="alert alert-secondary mt-2" role="alert">
-        Your updated email address needs verification. Until you click the link sent to <strong><%= me.emailChangeCandidate %></strong>, you will still need to sign in as <strong><%= me.emailAddress %></strong>.
+        Your updated email address needs verification. Until you click the link sent to <strong><%= me.emailChangeCandidate %></strong>, you&#39;ll still need to sign in as <strong><%= me.emailAddress %></strong>.
         </div>
       </div>
       <% } else if(me&&me.emailStatus === 'unconfirmed') { %>

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -75,7 +75,7 @@
       <% if(me&&me.emailChangeCandidate) { %>
       <div class="container-fluid">
         <div class="alert alert-secondary mt-2" role="alert">
-        Your updated email address needs verification. Until you click the link sent to <strong><%= me.emailChangeCandidate %></strong>, you'll still need to sign in as <strong><%= me.emailAddress %></strong>.
+        Your updated email address needs verification. Until you click the link sent to <strong><%= me.emailChangeCandidate %></strong>, you will still need to sign in as <strong><%= me.emailAddress %></strong>.
         </div>
       </div>
       <% } else if(me&&me.emailStatus === 'unconfirmed') { %>


### PR DESCRIPTION
I was evaluating the code examples and fell over this issue with the code highlighting not working properly due to the use of a contraction (see screenshot). 

Not being a native english speaker I had to read up on the use of contractions and contractions are completely okay (ref: https://www.vappingo.com/word-blog/when-is-it-okay-to-use-contractions-in-formal-writing/).

The PR proposes not using the contraction. The communication is intact and readability is improved.

![with-contaction](https://user-images.githubusercontent.com/75423/38490786-567df544-3bea-11e8-80e5-ed132fe8a807.png)
